### PR TITLE
Apply Ruff and isort fixes

### DIFF
--- a/RelevantEvents.py
+++ b/RelevantEvents.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 import sys
 import time
 
+
 def calculate_sunrise_sunset(date, latitude, longitude):
     """Calculate the sunrise and sunset times for the given date and location."""
     # Constants
@@ -22,44 +23,64 @@ def calculate_sunrise_sunset(date, latitude, longitude):
     # Sunrise calculations
     t_rise = N + ((6 - lng_hour) / 24)
     M_rise = (0.9856 * t_rise) - 3.289
-    L_rise = (M_rise + (1.916 * math.sin(math.radians(M_rise))) + (0.020 * math.sin(math.radians(2 * M_rise))) + 282.634) % 360
+    L_rise = (
+        M_rise
+        + (1.916 * math.sin(math.radians(M_rise)))
+        + (0.020 * math.sin(math.radians(2 * M_rise)))
+        + 282.634
+    ) % 360
     RA_rise = (math.degrees(math.atan(0.91764 * math.tan(math.radians(L_rise))))) % 360
-    Lquadrant_rise  = (math.floor(L_rise/90)) * 90
-    RAquadrant_rise = (math.floor(RA_rise/90)) * 90
+    Lquadrant_rise = (math.floor(L_rise / 90)) * 90
+    RAquadrant_rise = (math.floor(RA_rise / 90)) * 90
     RA_rise = RA_rise + (Lquadrant_rise - RAquadrant_rise)
     RA_rise = RA_rise / 15
     sinDec_rise = 0.39782 * math.sin(math.radians(L_rise))
     cosDec_rise = math.cos(math.asin(sinDec_rise))
-    cosH_rise = (math.cos(math.radians(zenith)) - (sinDec_rise * math.sin(math.radians(latitude)))) / (cosDec_rise * math.cos(math.radians(latitude)))
+    cosH_rise = (
+        math.cos(math.radians(zenith))
+        - (sinDec_rise * math.sin(math.radians(latitude)))
+    ) / (cosDec_rise * math.cos(math.radians(latitude)))
     if cosH_rise > 1:
         return None, None  # Sun never rises on this location (on the specified date)
     H_rise = 360 - math.degrees(math.acos(cosH_rise))
     H_rise = H_rise / 15
     T_rise = H_rise + RA_rise - (0.06571 * t_rise) - 6.622
     UT_rise = (T_rise - lng_hour) % 24
-    sunrise_time = datetime.datetime.combine(date, datetime.time(0, 0, 0)) + timedelta(hours=UT_rise)
+    sunrise_time = datetime.datetime.combine(date, datetime.time(0, 0, 0)) + timedelta(
+        hours=UT_rise
+    )
 
     # Sunset calculations
     t_set = N + ((18 - lng_hour) / 24)
     M_set = (0.9856 * t_set) - 3.289
-    L_set = (M_set + (1.916 * math.sin(math.radians(M_set))) + (0.020 * math.sin(math.radians(2 * M_set))) + 282.634) % 360
+    L_set = (
+        M_set
+        + (1.916 * math.sin(math.radians(M_set)))
+        + (0.020 * math.sin(math.radians(2 * M_set)))
+        + 282.634
+    ) % 360
     RA_set = (math.degrees(math.atan(0.91764 * math.tan(math.radians(L_set))))) % 360
-    Lquadrant_set  = (math.floor(L_set/90)) * 90
-    RAquadrant_set = (math.floor(RA_set/90)) * 90
+    Lquadrant_set = (math.floor(L_set / 90)) * 90
+    RAquadrant_set = (math.floor(RA_set / 90)) * 90
     RA_set = RA_set + (Lquadrant_set - RAquadrant_set)
     RA_set = RA_set / 15
     sinDec_set = 0.39782 * math.sin(math.radians(L_set))
     cosDec_set = math.cos(math.asin(sinDec_set))
-    cosH_set = (math.cos(math.radians(zenith)) - (sinDec_set * math.sin(math.radians(latitude)))) / (cosDec_set * math.cos(math.radians(latitude)))
+    cosH_set = (
+        math.cos(math.radians(zenith)) - (sinDec_set * math.sin(math.radians(latitude)))
+    ) / (cosDec_set * math.cos(math.radians(latitude)))
     if cosH_set < -1:
         return None, None  # Sun never sets on this location (on the specified date)
     H_set = math.degrees(math.acos(cosH_set))
     H_set = H_set / 15
     T_set = H_set + RA_set - (0.06571 * t_set) - 6.622
     UT_set = (T_set - lng_hour) % 24
-    sunset_time = datetime.datetime.combine(date, datetime.time(0, 0, 0)) + timedelta(hours=UT_set)
+    sunset_time = datetime.datetime.combine(date, datetime.time(0, 0, 0)) + timedelta(
+        hours=UT_set
+    )
 
     return sunrise_time, sunset_time
+
 
 def calculate_events(current_time, latitude, longitude, offset):
     """Calculate the last event, next event, and the event after."""
@@ -72,10 +93,10 @@ def calculate_events(current_time, latitude, longitude, offset):
         # Adjust for offset
         if sunrise_time:
             sunrise_time += timedelta(minutes=offset)
-            events.append(('OFF', sunrise_time))
+            events.append(("OFF", sunrise_time))
         if sunset_time:
             sunset_time -= timedelta(minutes=offset)
-            events.append(('ON', sunset_time))
+            events.append(("ON", sunset_time))
 
     # Sort events by time
     events.sort(key=lambda x: x[1])
@@ -94,7 +115,7 @@ def calculate_events(current_time, latitude, longitude, offset):
     last_event = None
     next_event = None
     event_after = None
-    current_state = 'OFF'  # Default state
+    current_state = "OFF"  # Default state
 
     for event in filtered_events:
         if event[1] <= current_time:
@@ -106,6 +127,7 @@ def calculate_events(current_time, latitude, longitude, offset):
             event_after = event
 
     return last_event, next_event, event_after, current_state
+
 
 def write_to_db(styring_db, device_id, last_event, next_event, current_state):
     conn = sqlite3.connect(styring_db)
@@ -122,7 +144,8 @@ def write_to_db(styring_db, device_id, last_event, next_event, current_state):
 
     # Update the database
     try:
-        cursor.execute("""
+        cursor.execute(
+            """
             UPDATE heimtaugaskapar
             SET lastastrotime = ?,
                 lasastroOP = ?,
@@ -130,12 +153,22 @@ def write_to_db(styring_db, device_id, last_event, next_event, current_state):
                 nextastroOP = ?,
                 astrostate = ?
             WHERE id = ?
-        """, (lastastrotime, lasastroOP, nextastrotime, nextastroOP, astrostate, device_id))
+        """,
+            (
+                lastastrotime,
+                lasastroOP,
+                nextastrotime,
+                nextastroOP,
+                astrostate,
+                device_id,
+            ),
+        )
         conn.commit()
     except sqlite3.Error as e:
         print(f"An error occurred while updating the database for {device_id}: {e}")
     finally:
         conn.close()
+
 
 def get_all_devices(styring_db):
     """Retrieve all devices from the database."""
@@ -153,19 +186,21 @@ def get_all_devices(styring_db):
         conn.close()
     return devices
 
+
 def print_event_str(label, event):
     """Return the event string instead of printing."""
     if event and event[1]:
-        return f'{label}: {event[0]} @ {event[1].strftime("%d%b %H:%M:%S")}'
+        return f"{label}: {event[0]} @ {event[1].strftime('%d%b %H:%M:%S')}"
     else:
-        return f'{label}: {event[0] if event else "No event"}'
+        return f"{label}: {event[0] if event else 'No event'}"
+
 
 def process_device(device_info, current_time, args, styring_db):
     """Process a single device."""
     messages = []
-    device_id = device_info['id']
-    latitude = device_info.get('lat')
-    longitude = device_info.get('lon')
+    device_id = device_info["id"]
+    latitude = device_info.get("lat")
+    longitude = device_info.get("lon")
 
     if latitude is None or longitude is None:
         msg = f"Device '{device_id}' does not have latitude and longitude information."
@@ -177,29 +212,52 @@ def process_device(device_info, current_time, args, styring_db):
 
         # Calculate events
         last_event, next_event, event_after, current_state = calculate_events(
-            current_time, latitude, longitude, args.offset)
+            current_time, latitude, longitude, args.offset
+        )
 
         if args.verbose:
             messages.append(f"\nDevice ID: {device_id}")
-            messages.append(f"It is now {current_time.strftime('%d%b %H:%M:%S')} UTC -- The Lights are {current_state}")
+            messages.append(
+                f"It is now {current_time.strftime('%d%b %H:%M:%S')} UTC -- The Lights are {current_state}"
+            )
             messages.append(f"The configured offset is: {args.offset} minutes")
-            messages.append(print_event_str('Last event', last_event))
-            messages.append(print_event_str('Next event', next_event))
-            messages.append(print_event_str('Event after', event_after))
+            messages.append(print_event_str("Last event", last_event))
+            messages.append(print_event_str("Next event", next_event))
+            messages.append(print_event_str("Event after", event_after))
 
         if args.write2db:
             write_to_db(styring_db, device_id, last_event, next_event, current_state)
 
     return messages
 
+
 # Main execution starts here
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Calculate events and update the database.")
-    parser.add_argument("--id", help="The device ID for which to calculate the event data.")
-    parser.add_argument("--test", nargs='*', help="Test mode with a specific date and time (e.g., Jun 16 12:34:56)")
-    parser.add_argument("--write2db", action="store_true", help="Write the results to the styring.db database.")
-    parser.add_argument("--verbose", action="store_true", help="Show detailed output for each device.")
-    parser.add_argument("--offset", type=int, default=0, help="Offset in minutes for lights ON/OFF times")
+    parser = argparse.ArgumentParser(
+        description="Calculate events and update the database."
+    )
+    parser.add_argument(
+        "--id", help="The device ID for which to calculate the event data."
+    )
+    parser.add_argument(
+        "--test",
+        nargs="*",
+        help="Test mode with a specific date and time (e.g., Jun 16 12:34:56)",
+    )
+    parser.add_argument(
+        "--write2db",
+        action="store_true",
+        help="Write the results to the styring.db database.",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", help="Show detailed output for each device."
+    )
+    parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Offset in minutes for lights ON/OFF times",
+    )
     args = parser.parse_args()
 
     styring_db = "styring.db"
@@ -209,7 +267,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     if args.test:
-        test_time_str = ' '.join(args.test)
+        test_time_str = " ".join(args.test)
         try:
             current_time = datetime.datetime.strptime(test_time_str, "%b %d %H:%M:%S")
         except ValueError:
@@ -268,7 +326,9 @@ if __name__ == "__main__":
                             print(msg)
                     else:
                         # Output a single line with timestamp
-                        timestamp = datetime.datetime.now().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3]
+                        timestamp = datetime.datetime.now().strftime(
+                            "%Y-%m-%dT%H:%M:%S.%f"
+                        )[:-3]
                         print(f"{timestamp} - Updated event data for all devices.")
                     # Clear the messages
                     output_messages = []

--- a/RelevantEvents.py
+++ b/RelevantEvents.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 
-import sqlite3
 import argparse
-import math
 import datetime
-from datetime import timedelta
+import math
+import sqlite3
 import sys
 import time
+from datetime import timedelta
 
 
 def calculate_sunrise_sunset(date, latitude, longitude):

--- a/apiState.py
+++ b/apiState.py
@@ -12,9 +12,10 @@ load_dotenv()
 USERNAME = get_key(".env", "USERNAME")
 PASSWORD = os.getenv("PASSWORD")
 
-DB_NAME = 'styring.db'  # Update this to your actual database name if different
+DB_NAME = "styring.db"  # Update this to your actual database name if different
 TIMEOUT = 5  # Timeout for API requests in seconds
 RETRY_LIMIT = 3  # Number of times to retry the API request
+
 
 # Function to get data from SQLite DB by device ID
 def get_device_info_by_id(device_id):
@@ -28,9 +29,15 @@ def get_device_info_by_id(device_id):
     conn.close()
 
     if result:
-        return {'id': result[0], 'ip': result[1], 'input_pin': result[2], 'output_pin': result[3]}
+        return {
+            "id": result[0],
+            "ip": result[1],
+            "input_pin": result[2],
+            "output_pin": result[3],
+        }
     else:
         raise ValueError(f"No device found with id {device_id}")
+
 
 # Function to get data from SQLite DB by HS number
 def get_device_info_by_hs(hs):
@@ -44,9 +51,15 @@ def get_device_info_by_hs(hs):
     conn.close()
 
     if result:
-        return {'id': result[0], 'ip': result[1], 'input_pin': result[2], 'output_pin': result[3]}
+        return {
+            "id": result[0],
+            "ip": result[1],
+            "input_pin": result[2],
+            "output_pin": result[3],
+        }
     else:
         raise ValueError(f"No device found with hs {hs}")
+
 
 # Function to get output or input pin by IP address
 def get_device_info_by_ip(ip):
@@ -60,16 +73,17 @@ def get_device_info_by_ip(ip):
     conn.close()
 
     if result:
-        return {'id': result[0], 'input_pin': result[1], 'output_pin': result[2]}
+        return {"id": result[0], "input_pin": result[1], "output_pin": result[2]}
     else:
         raise ValueError(f"No device found with IP {ip}")
 
+
 # Function to check the state of a pin via API (input or output based on --var flag)
 def check_pin_state(device_info, var):
-    ip = device_info['ip']
-    
+    ip = device_info["ip"]
+
     # Select pin based on --var flag (either input_pin or output_pin)
-    pin = device_info['input_pin'] if var == 'inputstate' else device_info['output_pin']
+    pin = device_info["input_pin"] if var == "inputstate" else device_info["output_pin"]
 
     # Construct the URL with plain-text credentials in the query string
     url = f"http://{ip}/cgi-bin/io_value?username={USERNAME}&password={PASSWORD}&pin={pin}"
@@ -80,19 +94,25 @@ def check_pin_state(device_info, var):
             response = requests.get(url, timeout=TIMEOUT)
 
             if response.status_code == 200:
-                pin_state = response.text.strip()  # Get the pin state from the API response (0 or 1)
+                pin_state = (
+                    response.text.strip()
+                )  # Get the pin state from the API response (0 or 1)
                 print(f"Pin state for {pin} at IP {ip}: {pin_state}")
                 return pin_state
             else:
                 print(f"Failed to send request. Status code: {response.status_code}")
                 return None
         except requests.exceptions.RequestException as e:
-            print(f"Attempt {attempt+1}/{RETRY_LIMIT}: Error communicating with {ip}: {e}")
+            print(
+                f"Attempt {attempt + 1}/{RETRY_LIMIT}: Error communicating with {ip}: {e}"
+            )
 
     return None
 
+
 # Function to update the DB using updateDBcell.py script
 def update_db(device_id, col_to_change, new_value):
+    # fmt: off
     command = [
         "python3", "updateDBcell.py",
         "--db", DB_NAME,
@@ -100,24 +120,33 @@ def update_db(device_id, col_to_change, new_value):
         "--colchange", col_to_change,
         "--colname", "id",
         "--colnamerow", device_id,
-        "--newval", new_value
+        "--newval", new_value,
     ]
-    
+    # fmt: on
+
     result = subprocess.run(command, capture_output=True, text=True)
     print(result.stdout)
 
+
 # Main function to handle command-line arguments
 def main():
-    parser = argparse.ArgumentParser(description="Check device pin state and update the database.")
+    parser = argparse.ArgumentParser(
+        description="Check device pin state and update the database."
+    )
 
     # Mutually exclusive arguments for selecting the device
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--id', help="ID of the device")
-    group.add_argument('--hs', help="HS number of the device")
-    group.add_argument('--ip', help="IP address of the device")
+    group.add_argument("--id", help="ID of the device")
+    group.add_argument("--hs", help="HS number of the device")
+    group.add_argument("--ip", help="IP address of the device")
 
     # Column to update in the DB, now supporting both inputstate and outputstate
-    parser.add_argument('--var', choices=['inputstate', 'outputstate'], required=True, help="Variable to update (e.g., inputstate or outputstate)")
+    parser.add_argument(
+        "--var",
+        choices=["inputstate", "outputstate"],
+        required=True,
+        help="Variable to update (e.g., inputstate or outputstate)",
+    )
 
     args = parser.parse_args()
 
@@ -129,19 +158,20 @@ def main():
             device_info = get_device_info_by_hs(args.hs)
         elif args.ip:
             device_info = get_device_info_by_ip(args.ip)
-            device_info['ip'] = args.ip  # IP is directly provided, no need to look up
+            device_info["ip"] = args.ip  # IP is directly provided, no need to look up
 
         # Check the pin state (input or output) via API
         pin_state = check_pin_state(device_info, args.var)
 
         # Update the database if pin_state is retrieved successfully
         if pin_state is not None:
-            new_value = 'ON' if pin_state == '1' else 'OFF'
-            update_db(device_info['id'], args.var, new_value)
+            new_value = "ON" if pin_state == "1" else "OFF"
+            update_db(device_info["id"], args.var, new_value)
         else:
             print("Failed to retrieve pin state.")
     except Exception as e:
         print(f"Error: {e}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/apiState.py
+++ b/apiState.py
@@ -1,9 +1,10 @@
 import argparse
-import sqlite3
-import requests
 import os
+import sqlite3
 import subprocess
-from dotenv import load_dotenv, get_key
+
+import requests
+from dotenv import get_key, load_dotenv
 
 # Load environment variables
 load_dotenv()

--- a/apiTurn.py
+++ b/apiTurn.py
@@ -12,9 +12,10 @@ load_dotenv()
 USERNAME = get_key(".env", "USERNAME")
 PASSWORD = os.getenv("PASSWORD")
 
-DB_NAME = 'styring.db'  # Update this to your actual database name if different
+DB_NAME = "styring.db"  # Update this to your actual database name if different
 TIMEOUT = 5  # Timeout for API requests in seconds
 RETRY_LIMIT = 3  # Number of times to retry the API request
+
 
 # Function to get data from SQLite DB by device ID
 def get_device_info_by_id(device_id):
@@ -28,9 +29,15 @@ def get_device_info_by_id(device_id):
     conn.close()
 
     if result:
-        return {'id': result[0], 'ip': result[1], 'input_pin': result[2], 'output_pin': result[3]}
+        return {
+            "id": result[0],
+            "ip": result[1],
+            "input_pin": result[2],
+            "output_pin": result[3],
+        }
     else:
         raise ValueError(f"No device found with id {device_id}")
+
 
 # Function to get data from SQLite DB by HS number
 def get_device_info_by_hs(hs):
@@ -44,63 +51,84 @@ def get_device_info_by_hs(hs):
     conn.close()
 
     if result:
-        return {'id': result[0], 'ip': result[1], 'input_pin': result[2], 'output_pin': result[3]}
+        return {
+            "id": result[0],
+            "ip": result[1],
+            "input_pin": result[2],
+            "output_pin": result[3],
+        }
     else:
         raise ValueError(f"No device found with hs {hs}")
 
+
 # Function to turn on/off the output
 def turn_output(device_info, state):
-    ip = device_info['ip']
-    pin = device_info['output_pin']
+    ip = device_info["ip"]
+    pin = device_info["output_pin"]
 
     # Construct the URL with plain-text credentials in the query string
     url = f"http://{ip}/cgi-bin/io_state?username={USERNAME}&password={PASSWORD}&pin={pin}&state={state.lower()}"
 
     # Print the URL without exposing the password
-    print(f"API URL: http://{ip}/cgi-bin/io_state?username={USERNAME}&pin={pin}&state={state.lower()} [password hidden]")
-    
+    print(
+        f"API URL: http://{ip}/cgi-bin/io_state?username={USERNAME}&pin={pin}&state={state.lower()} [password hidden]"
+    )
+
     # Send the request
     for attempt in range(RETRY_LIMIT):
         try:
             response = requests.get(url, timeout=TIMEOUT)
 
             if response.status_code == 200:
-                print(f"Successfully turned {state.upper()} {pin} for device with IP {ip}")
+                print(
+                    f"Successfully turned {state.upper()} {pin} for device with IP {ip}"
+                )
                 return {"status": "success", "ip": ip, "pin": pin}
             else:
                 print(f"Failed to send request. Status code: {response.status_code}")
-                return {"status": "failure", "ip": ip, "pin": pin, "reason": "HTTP error", "code": response.status_code}
+                return {
+                    "status": "failure",
+                    "ip": ip,
+                    "pin": pin,
+                    "reason": "HTTP error",
+                    "code": response.status_code,
+                }
 
         except requests.exceptions.RequestException as e:
-            print(f"Attempt {attempt+1}/{RETRY_LIMIT}: Error communicating with {ip}: {e}")
+            print(
+                f"Attempt {attempt + 1}/{RETRY_LIMIT}: Error communicating with {ip}: {e}"
+            )
 
     return {"status": "failure", "ip": ip, "pin": pin, "reason": "max retries exceeded"}
+
 
 # Function to check the pin state (input or output) via API and update the database
 def check_and_update_pin_state(device_info, var):
     # Construct the URL for checking the pin state
-    ip = device_info['ip']
-    pin = device_info['input_pin'] if var == 'inputstate' else device_info['output_pin']
+    ip = device_info["ip"]
+    pin = device_info["input_pin"] if var == "inputstate" else device_info["output_pin"]
 
     url = f"http://{ip}/cgi-bin/io_value?username={USERNAME}&password={PASSWORD}&pin={pin}"
-    
+
     # Send the request
     try:
         response = requests.get(url, timeout=TIMEOUT)
         if response.status_code == 200:
             pin_state = response.text.strip()  # Get the pin state (0 or 1)
-            new_value = 'ON' if pin_state == '1' else 'OFF'
+            new_value = "ON" if pin_state == "1" else "OFF"
             print(f"{var.capitalize()} for {pin} at IP {ip}: {new_value}")
 
             # Update the database using updateDBcell.py script
-            update_db(device_info['id'], var, new_value)
+            update_db(device_info["id"], var, new_value)
         else:
             print(f"Failed to check {var}. Status code: {response.status_code}")
     except requests.exceptions.RequestException as e:
         print(f"Error communicating with {ip} for {var}: {e}")
 
+
 # Function to update the database using updateDBcell.py script
 def update_db(device_id, col_to_change, new_value):
+    # fmt: off
     command = [
         "python3", "updateDBcell.py",
         "--db", DB_NAME,
@@ -108,21 +136,30 @@ def update_db(device_id, col_to_change, new_value):
         "--colchange", col_to_change,
         "--colname", "id",
         "--colnamerow", device_id,
-        "--newval", new_value
+        "--newval", new_value,
     ]
-    
+    # fmt: on
+
     result = subprocess.run(command, capture_output=True, text=True)
     print(result.stdout)
 
+
 # Main function to handle command-line arguments
 def main():
-    parser = argparse.ArgumentParser(description="Turn device output on or off and verify the state change.")
+    parser = argparse.ArgumentParser(
+        description="Turn device output on or off and verify the state change."
+    )
 
     group = parser.add_mutually_exclusive_group(required=True)
-    group.add_argument('--id', help="ID of the device")
-    group.add_argument('--hs', help="HS number of the device")
+    group.add_argument("--id", help="ID of the device")
+    group.add_argument("--hs", help="HS number of the device")
 
-    parser.add_argument('--turn', choices=['ON', 'OFF', 'on', 'off'], required=True, help="Turn output ON or OFF")
+    parser.add_argument(
+        "--turn",
+        choices=["ON", "OFF", "on", "off"],
+        required=True,
+        help="Turn output ON or OFF",
+    )
 
     args = parser.parse_args()
 
@@ -136,12 +173,13 @@ def main():
         result = turn_output(device_info, args.turn.upper())
 
         # If the API call was successful, check and update both outputstate and inputstate
-        if result['status'] == 'success':
-            check_and_update_pin_state(device_info, 'outputstate')
-            check_and_update_pin_state(device_info, 'inputstate')
+        if result["status"] == "success":
+            check_and_update_pin_state(device_info, "outputstate")
+            check_and_update_pin_state(device_info, "inputstate")
 
     except Exception as e:
         print(f"Error: {e}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/apiTurn.py
+++ b/apiTurn.py
@@ -1,9 +1,10 @@
 import argparse
-import sqlite3
-import requests
 import os
+import sqlite3
 import subprocess
-from dotenv import load_dotenv, get_key
+
+import requests
+from dotenv import get_key, load_dotenv
 
 # Load environment variables
 load_dotenv()

--- a/astro.py
+++ b/astro.py
@@ -1,6 +1,6 @@
 import sqlite3
-import time
 import subprocess
+import time
 
 DB_NAME = "styring.db"  # Database name
 CHECK_INTERVAL = 1  # Interval between processing devices in seconds

--- a/astro.py
+++ b/astro.py
@@ -2,75 +2,94 @@ import sqlite3
 import time
 import subprocess
 
-DB_NAME = 'styring.db'  # Database name
+DB_NAME = "styring.db"  # Database name
 CHECK_INTERVAL = 1  # Interval between processing devices in seconds
 
+
 def update_uxstate(device_id, new_value):
+    # fmt: off
     command = [
-        'python3', 'updateDBcell.py',
-        '--db', DB_NAME,
-        '--table', 'heimtaugaskapar',
-        '--colchange', 'uxstate',
-        '--colname', 'id',
-        '--colnamerow', device_id,
-        '--newval', new_value
+        "python3", "updateDBcell.py",
+        "--db", DB_NAME,
+        "--table", "heimtaugaskapar",
+        "--colchange", "uxstate",
+        "--colname", "id",
+        "--colnamerow", device_id,
+        "--newval", new_value,
     ]
+    # fmt: on
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Error updating uxstate for device {device_id}: {result.stderr}")
     else:
         print(f"Updated uxstate for device {device_id} to {new_value}.")
 
+
 def main():
     while True:
         conn = sqlite3.connect(DB_NAME)
         cursor = conn.cursor()
-        
+
         # Fetch all devices from the heimtaugaskapar table
-        cursor.execute("SELECT id, astroman, astrostate, outputstate FROM heimtaugaskapar")
+        cursor.execute(
+            "SELECT id, astroman, astrostate, outputstate FROM heimtaugaskapar"
+        )
         devices = cursor.fetchall()
-        
+
         conn.close()
-        
+
         for device in devices:
             device_id = device[0]
             astroman = device[1]
             astrostate = device[2]
             outputstate = device[3]
-            
-            if astroman == 'MANUAL':
+
+            if astroman == "MANUAL":
                 # Do nothing and move to the next device
                 print(f"Device {device_id} is in MANUAL mode. Skipping.")
                 continue
-            elif astroman == 'ASTRO':
+            elif astroman == "ASTRO":
                 # Update uxstate to match astrostate
                 update_uxstate(device_id, astrostate)
-                
+
                 # Check if astrostate is not the same as outputstate
                 if astrostate != outputstate:
                     # Determine the action based on astrostate
-                    if astrostate in ['ON', 'OFF']:
+                    if astrostate in ["ON", "OFF"]:
                         turn_state = astrostate
                         # Use apiTurn.py to send the command
+                        # fmt: off
                         command = [
-                            'python3', 'apiTurn.py',
-                            '--id', device_id,
-                            '--turn', turn_state
+                            "python3", "apiTurn.py",
+                            "--id", device_id,
+                            "--turn", turn_state,
                         ]
+                        # fmt: on
                         result = subprocess.run(command, capture_output=True, text=True)
                         if result.returncode != 0:
-                            print(f"Error turning {turn_state} device {device_id}: {result.stderr}")
+                            print(
+                                f"Error turning {turn_state} device {device_id}: {result.stderr}"
+                            )
                         else:
-                            print(f"Turned {turn_state} device {device_id}: {result.stdout}")
+                            print(
+                                f"Turned {turn_state} device {device_id}: {result.stdout}"
+                            )
                     else:
-                        print(f"Device {device_id} has invalid astrostate '{astrostate}'. Skipping.")
+                        print(
+                            f"Device {device_id} has invalid astrostate '{astrostate}'. Skipping."
+                        )
                 else:
-                    print(f"Device {device_id}: astrostate matches outputstate. No action needed.")
+                    print(
+                        f"Device {device_id}: astrostate matches outputstate. No action needed."
+                    )
             else:
-                print(f"Device {device_id} has invalid astroman value '{astroman}'. Skipping.")
-            
+                print(
+                    f"Device {device_id} has invalid astroman value '{astroman}'. Skipping."
+                )
+
             # Wait before processing the next device
             time.sleep(CHECK_INTERVAL)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/checkStates.py
+++ b/checkStates.py
@@ -1,6 +1,6 @@
 import sqlite3
-import time
 import subprocess
+import time
 
 DB_NAME = "styring.db"  # Database name
 CHECK_INTERVAL = 10  # Minimum interval between API requests in seconds

--- a/checkStates.py
+++ b/checkStates.py
@@ -2,8 +2,9 @@ import sqlite3
 import time
 import subprocess
 
-DB_NAME = 'styring.db'  # Database name
+DB_NAME = "styring.db"  # Database name
 CHECK_INTERVAL = 10  # Minimum interval between API requests in seconds
+
 
 # Function to get all devices from the heimtaugaskapar table
 def get_all_devices():
@@ -18,19 +19,17 @@ def get_all_devices():
 
     return [device[0] for device in devices]
 
+
 # Function to call apiState.py for inputstate or outputstate
 def check_state(device_id, var):
-    command = [
-        "python3", "apiState.py",
-        "--id", device_id,
-        "--var", var
-    ]
-    
+    command = ["python3", "apiState.py", "--id", device_id, "--var", var]
+
     result = subprocess.run(command, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"Error checking {var} for device {device_id}: {result.stderr}")
     else:
         print(f"{var} checked for device {device_id}: {result.stdout}")
+
 
 # Function to compare inputstate and outputstate and update localremote
 def update_localremote(device_id):
@@ -38,7 +37,9 @@ def update_localremote(device_id):
     cursor = conn.cursor()
 
     # Get inputstate and outputstate
-    cursor.execute("SELECT inputstate, outputstate FROM heimtaugaskapar WHERE id = ?", (device_id,))
+    cursor.execute(
+        "SELECT inputstate, outputstate FROM heimtaugaskapar WHERE id = ?", (device_id,)
+    )
     row = cursor.fetchone()
 
     if row:
@@ -46,18 +47,22 @@ def update_localremote(device_id):
         outputstate = row[1]
 
         if inputstate != outputstate:
-            localremote = 'LOCAL'
+            localremote = "LOCAL"
         else:
-            localremote = 'REMOTE'
+            localremote = "REMOTE"
 
         # Update localremote
-        cursor.execute("UPDATE heimtaugaskapar SET localremote = ? WHERE id = ?", (localremote, device_id))
+        cursor.execute(
+            "UPDATE heimtaugaskapar SET localremote = ? WHERE id = ?",
+            (localremote, device_id),
+        )
         conn.commit()
         print(f"Updated localremote for device {device_id} to {localremote}")
     else:
         print(f"Device {device_id} not found in database.")
 
     conn.close()
+
 
 # Main loop that checks both inputstate and outputstate for each device
 def main():
@@ -80,5 +85,6 @@ def main():
             # Optional: Uncomment the following line if you want an additional delay
             # time.sleep(CHECK_INTERVAL)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/intrapi.py
+++ b/intrapi.py
@@ -1,6 +1,6 @@
 # intrapi.py
 
-from flask import Flask, request, abort, Response, make_response
+from flask import Flask, request, abort, Response
 import sqlite3
 import subprocess
 import json

--- a/intrapi.py
+++ b/intrapi.py
@@ -1,10 +1,11 @@
 # intrapi.py
 
-from flask import Flask, request, abort, Response
+import json
 import sqlite3
 import subprocess
-import json
 from functools import wraps
+
+from flask import Flask, Response, abort, request
 
 app = Flask(__name__)
 

--- a/intrapi.py
+++ b/intrapi.py
@@ -8,38 +8,44 @@ from functools import wraps
 
 app = Flask(__name__)
 
-DATABASE = 'styring.db'
-SECRET_FILE = 'secret'
+DATABASE = "styring.db"
+SECRET_FILE = "secret"
+
 
 def get_db_connection():
     conn = sqlite3.connect(DATABASE)
     conn.row_factory = sqlite3.Row  # Enable dict-like access to rows
     return conn
 
+
 # Load Id and Secret from the 'secret' file
 def load_credentials():
     credentials = {}
-    with open(SECRET_FILE, 'r') as f:
+    with open(SECRET_FILE, "r") as f:
         for line in f:
             if line.strip():  # Skip empty lines
-                key, value = line.strip().split(':', 1)
+                key, value = line.strip().split(":", 1)
                 credentials[key.strip()] = value.strip()
     return credentials
 
+
 credentials = load_credentials()
-AUTH_ID = credentials.get('Id')
-AUTH_SECRET = credentials.get('Secret')
+AUTH_ID = credentials.get("Id")
+AUTH_SECRET = credentials.get("Secret")
+
 
 # Authentication decorator
 def require_auth(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        client_id = request.headers.get('CF-Access-Client-Id')
-        client_secret = request.headers.get('CF-Access-Client-Secret')
+        client_id = request.headers.get("CF-Access-Client-Id")
+        client_secret = request.headers.get("CF-Access-Client-Secret")
         if client_id != AUTH_ID or client_secret != AUTH_SECRET:
-            return Response('Unauthorized', status=401)
+            return Response("Unauthorized", status=401)
         return func(*args, **kwargs)
+
     return wrapper
+
 
 # Helper function to get device by id or hs
 def get_device_by_identifier(identifier):
@@ -54,7 +60,7 @@ def get_device_by_identifier(identifier):
         return dict(device)
 
     # Modify the identifier for hs lookup (replace '-' with '_')
-    hs_identifier = identifier.replace('-', '_')
+    hs_identifier = identifier.replace("-", "_")
 
     # Try to fetch by hs
     cursor.execute("SELECT * FROM heimtaugaskapar WHERE hs = ?", (hs_identifier,))
@@ -65,119 +71,146 @@ def get_device_by_identifier(identifier):
     else:
         return None
 
+
 # New root endpoint that returns the same as '/devices'
-@app.route('/', methods=['GET'])
+@app.route("/", methods=["GET"])
 @require_auth
 def root():
     return get_all_devices()
 
-@app.route('/devices', methods=['GET'])
+
+@app.route("/devices", methods=["GET"])
 @require_auth
 def get_all_devices():
     conn = get_db_connection()
-    devices = conn.execute('SELECT * FROM heimtaugaskapar').fetchall()
+    devices = conn.execute("SELECT * FROM heimtaugaskapar").fetchall()
     conn.close()
     devices_list = [dict(device) for device in devices]
     response_json = json.dumps(devices_list, ensure_ascii=False)
-    return Response(response_json, content_type='application/json; charset=utf-8')
+    return Response(response_json, content_type="application/json; charset=utf-8")
 
-@app.route('/devices/<identifier>', methods=['GET'])
+
+@app.route("/devices/<identifier>", methods=["GET"])
 @require_auth
 def get_device(identifier):
     device = get_device_by_identifier(identifier)
     if device:
         response_json = json.dumps(device, ensure_ascii=False)
-        return Response(response_json, content_type='application/json; charset=utf-8')
+        return Response(response_json, content_type="application/json; charset=utf-8")
     else:
         abort(404, description="Device not found")
 
-@app.route('/devices/<identifier>/state', methods=['GET', 'POST'])
+
+@app.route("/devices/<identifier>/state", methods=["GET", "POST"])
 @require_auth
 def device_state(identifier):
     device = get_device_by_identifier(identifier)
     if not device:
         abort(404, description="Device not found")
 
-    if request.method == 'GET':
+    if request.method == "GET":
         # Return the current state
         data = {
-            'id': device['id'],
-            'state': device['outputstate'],
-            'astroman': device['astroman']
+            "id": device["id"],
+            "state": device["outputstate"],
+            "astroman": device["astroman"],
         }
         response_json = json.dumps(data, ensure_ascii=False)
-        return Response(response_json, content_type='application/json; charset=utf-8')
-    elif request.method == 'POST':
+        return Response(response_json, content_type="application/json; charset=utf-8")
+    elif request.method == "POST":
         # Check if device is in MANUAL mode
-        if device['astroman'] != 'MANUAL':
-            response = {'error': 'Device is not in MANUAL mode'}
+        if device["astroman"] != "MANUAL":
+            response = {"error": "Device is not in MANUAL mode"}
             response_json = json.dumps(response, ensure_ascii=False)
-            return Response(response_json, status=403, content_type='application/json; charset=utf-8')
+            return Response(
+                response_json,
+                status=403,
+                content_type="application/json; charset=utf-8",
+            )
 
         # Get the desired state from the request data
         data = request.get_json()
-        if not data or 'state' not in data:
+        if not data or "state" not in data:
             abort(400, description="Missing 'state' in request data")
 
-        new_state = data['state'].upper()
-        if new_state not in ['ON', 'OFF']:
+        new_state = data["state"].upper()
+        if new_state not in ["ON", "OFF"]:
             abort(400, description="Invalid state. Must be 'ON' or 'OFF'.")
 
         # Call apiTurn.py to change the state
         result = subprocess.run(
-            ['python3', 'apiTurn.py', '--id', device['id'], '--turn', new_state],
-            capture_output=True, text=True
+            ["python3", "apiTurn.py", "--id", device["id"], "--turn", new_state],
+            capture_output=True,
+            text=True,
         )
 
         if result.returncode != 0:
-            response = {'error': 'Failed to change device state', 'details': result.stderr}
+            response = {
+                "error": "Failed to change device state",
+                "details": result.stderr,
+            }
             response_json = json.dumps(response, ensure_ascii=False)
-            return Response(response_json, status=500, content_type='application/json; charset=utf-8')
+            return Response(
+                response_json,
+                status=500,
+                content_type="application/json; charset=utf-8",
+            )
         else:
             # Update uxstate in the database
             conn = get_db_connection()
-            conn.execute('UPDATE heimtaugaskapar SET uxstate = ? WHERE id = ?', (new_state, device['id']))
+            conn.execute(
+                "UPDATE heimtaugaskapar SET uxstate = ? WHERE id = ?",
+                (new_state, device["id"]),
+            )
             conn.commit()
             conn.close()
-            response = {'message': f'Device {device["id"]} turned {new_state} successfully'}
+            response = {
+                "message": f"Device {device['id']} turned {new_state} successfully"
+            }
             response_json = json.dumps(response, ensure_ascii=False)
-            return Response(response_json, content_type='application/json; charset=utf-8')
+            return Response(
+                response_json, content_type="application/json; charset=utf-8"
+            )
 
-@app.route('/devices/<identifier>/astroman', methods=['GET', 'POST'])
+
+@app.route("/devices/<identifier>/astroman", methods=["GET", "POST"])
 @require_auth
 def device_astroman(identifier):
     device = get_device_by_identifier(identifier)
     if not device:
         abort(404, description="Device not found")
 
-    if request.method == 'GET':
-        data = {
-            'id': device['id'],
-            'astroman': device['astroman']
-        }
+    if request.method == "GET":
+        data = {"id": device["id"], "astroman": device["astroman"]}
         response_json = json.dumps(data, ensure_ascii=False)
-        return Response(response_json, content_type='application/json; charset=utf-8')
-    elif request.method == 'POST':
+        return Response(response_json, content_type="application/json; charset=utf-8")
+    elif request.method == "POST":
         # Get the desired astroman value from the request data
         data = request.get_json()
-        if not data or 'astroman' not in data:
+        if not data or "astroman" not in data:
             abort(400, description="Missing 'astroman' in request data")
 
-        new_mode = data['astroman'].upper()
-        if new_mode not in ['ASTRO', 'MANUAL']:
-            abort(400, description="Invalid astroman value. Must be 'ASTRO' or 'MANUAL'.")
+        new_mode = data["astroman"].upper()
+        if new_mode not in ["ASTRO", "MANUAL"]:
+            abort(
+                400, description="Invalid astroman value. Must be 'ASTRO' or 'MANUAL'."
+            )
 
         # Update the database
         conn = get_db_connection()
-        conn.execute('UPDATE heimtaugaskapar SET astroman = ? WHERE id = ?', (new_mode, device['id']))
+        conn.execute(
+            "UPDATE heimtaugaskapar SET astroman = ? WHERE id = ?",
+            (new_mode, device["id"]),
+        )
         conn.commit()
         conn.close()
 
-        response = {'message': f'Device {device["id"]} astroman set to {new_mode}'}
+        response = {"message": f"Device {device['id']} astroman set to {new_mode}"}
         response_json = json.dumps(response, ensure_ascii=False)
-        return Response(response_json, content_type='application/json; charset=utf-8')
+        return Response(response_json, content_type="application/json; charset=utf-8")
 
-@app.route('/devices/<identifier>/fields/<field_name>', methods=['GET'])
+
+@app.route("/devices/<identifier>/fields/<field_name>", methods=["GET"])
 @require_auth
 def get_device_field(identifier, field_name):
     device = get_device_by_identifier(identifier)
@@ -191,10 +224,11 @@ def get_device_field(identifier, field_name):
 
     data = {field_name: device[field_name]}
     response_json = json.dumps(data, ensure_ascii=False)
-    return Response(response_json, content_type='application/json; charset=utf-8')
+    return Response(response_json, content_type="application/json; charset=utf-8")
+
 
 # Endpoint for nextastro
-@app.route('/devices/<identifier>/nextastro', methods=['GET'])
+@app.route("/devices/<identifier>/nextastro", methods=["GET"])
 @require_auth
 def device_nextastro(identifier):
     device = get_device_by_identifier(identifier)
@@ -202,15 +236,16 @@ def device_nextastro(identifier):
         abort(404, description="Device not found")
 
     data = {
-        'id': device['id'],
-        'nextastrotime': device.get('nextastrotime'),
-        'nextastroOP': device.get('nextastroOP')
+        "id": device["id"],
+        "nextastrotime": device.get("nextastrotime"),
+        "nextastroOP": device.get("nextastroOP"),
     }
     response_json = json.dumps(data, ensure_ascii=False)
-    return Response(response_json, content_type='application/json; charset=utf-8')
+    return Response(response_json, content_type="application/json; charset=utf-8")
+
 
 # Endpoint for lastastro
-@app.route('/devices/<identifier>/lastastro', methods=['GET'])
+@app.route("/devices/<identifier>/lastastro", methods=["GET"])
 @require_auth
 def device_lastastro(identifier):
     device = get_device_by_identifier(identifier)
@@ -218,43 +253,59 @@ def device_lastastro(identifier):
         abort(404, description="Device not found")
 
     data = {
-        'id': device['id'],
-        'lastastrotime': device.get('lastastrotime'),
-        'lasastroOP': device.get('lasastroOP')
+        "id": device["id"],
+        "lastastrotime": device.get("lastastrotime"),
+        "lasastroOP": device.get("lasastroOP"),
     }
     response_json = json.dumps(data, ensure_ascii=False)
-    return Response(response_json, content_type='application/json; charset=utf-8')
+    return Response(response_json, content_type="application/json; charset=utf-8")
+
 
 # Custom error handlers to ensure non-ASCII characters are handled
 @app.errorhandler(400)
 def bad_request(e):
-    response = {'error': str(e)}
+    response = {"error": str(e)}
     response_json = json.dumps(response, ensure_ascii=False)
-    return Response(response_json, status=400, content_type='application/json; charset=utf-8')
+    return Response(
+        response_json, status=400, content_type="application/json; charset=utf-8"
+    )
+
 
 @app.errorhandler(401)
 def unauthorized(e):
-    response = {'error': 'Unauthorized access'}
+    response = {"error": "Unauthorized access"}
     response_json = json.dumps(response, ensure_ascii=False)
-    return Response(response_json, status=401, content_type='application/json; charset=utf-8')
+    return Response(
+        response_json, status=401, content_type="application/json; charset=utf-8"
+    )
+
 
 @app.errorhandler(403)
 def forbidden(e):
-    response = {'error': str(e)}
+    response = {"error": str(e)}
     response_json = json.dumps(response, ensure_ascii=False)
-    return Response(response_json, status=403, content_type='application/json; charset=utf-8')
+    return Response(
+        response_json, status=403, content_type="application/json; charset=utf-8"
+    )
+
 
 @app.errorhandler(404)
 def resource_not_found(e):
-    response = {'error': str(e)}
+    response = {"error": str(e)}
     response_json = json.dumps(response, ensure_ascii=False)
-    return Response(response_json, status=404, content_type='application/json; charset=utf-8')
+    return Response(
+        response_json, status=404, content_type="application/json; charset=utf-8"
+    )
+
 
 @app.errorhandler(500)
 def internal_server_error(e):
-    response = {'error': 'Internal server error'}
+    response = {"error": "Internal server error"}
     response_json = json.dumps(response, ensure_ascii=False)
-    return Response(response_json, status=500, content_type='application/json; charset=utf-8')
+    return Response(
+        response_json, status=500, content_type="application/json; charset=utf-8"
+    )
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5053)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5053)

--- a/showDBflask.py
+++ b/showDBflask.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template_string, abort, request, redirect, url_for, Response
+from flask import Flask, render_template_string, abort, Response
 import sqlite3
 import csv
 import io

--- a/showDBflask.py
+++ b/showDBflask.py
@@ -1,8 +1,9 @@
-from flask import Flask, render_template_string, abort, Response
-import sqlite3
+import argparse
 import csv
 import io
-import argparse
+import sqlite3
+
+from flask import Flask, Response, abort, render_template_string
 
 app = Flask(__name__)
 

--- a/showDBflask.py
+++ b/showDBflask.py
@@ -55,19 +55,21 @@ th, td {
 </html>
 """
 
+
 # Function to connect to your database
 def get_db_connection(db_name):
     conn = sqlite3.connect(db_name)
     conn.row_factory = sqlite3.Row
     return conn
 
+
 # Route to display tables and data
-@app.route('/', defaults={'table_name': None})
-@app.route('/<table_name>')
+@app.route("/", defaults={"table_name": None})
+@app.route("/<table_name>")
 def show_table(table_name):
-    conn = get_db_connection(app.config['DB_NAME'])
+    conn = get_db_connection(app.config["DB_NAME"])
     cur = conn.cursor()
-    
+
     if table_name is None:
         # List all tables
         cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
@@ -84,12 +86,15 @@ def show_table(table_name):
         rows = cur.fetchall()
         columns = [description[0] for description in cur.description]
         conn.close()
-        return render_template_string(HTML_TEMPLATE, table_name=table_name, rows=rows, columns=columns)
+        return render_template_string(
+            HTML_TEMPLATE, table_name=table_name, rows=rows, columns=columns
+        )
+
 
 # Route to download table as CSV
-@app.route('/download/<table_name>/csv')
+@app.route("/download/<table_name>/csv")
 def download_csv(table_name):
-    conn = get_db_connection(app.config['DB_NAME'])
+    conn = get_db_connection(app.config["DB_NAME"])
     cur = conn.cursor()
     try:
         cur.execute(f'SELECT * FROM "{table_name}"')
@@ -107,20 +112,31 @@ def download_csv(table_name):
     for row in rows:
         writer.writerow(row)
     output.seek(0)
-    return Response(output, mimetype='text/csv',
-                    headers={"Content-Disposition": f"attachment;filename={table_name}.csv"})
+    return Response(
+        output,
+        mimetype="text/csv",
+        headers={"Content-Disposition": f"attachment;filename={table_name}.csv"},
+    )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     # Argument parser for database name and port
-    parser = argparse.ArgumentParser(description='Run Flask app with SQLite database.')
-    parser.add_argument('--db', type=str, required=True, help='The SQLite database file to use')
-    parser.add_argument('--port', type=int, default=5000, help='The port to run the Flask app on (default is 5000)')
-    
+    parser = argparse.ArgumentParser(description="Run Flask app with SQLite database.")
+    parser.add_argument(
+        "--db", type=str, required=True, help="The SQLite database file to use"
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=5000,
+        help="The port to run the Flask app on (default is 5000)",
+    )
+
     # Parse arguments
     args = parser.parse_args()
-    
+
     # Pass the database name as a Flask app config
-    app.config['DB_NAME'] = args.db
-    
+    app.config["DB_NAME"] = args.db
+
     # Run the Flask app with the specified port
-    app.run(host='0.0.0.0', port=args.port)
+    app.run(host="0.0.0.0", port=args.port)

--- a/updateDBcell.py
+++ b/updateDBcell.py
@@ -1,8 +1,11 @@
 import argparse
 import sqlite3
 
+
 # Function to update a specific cell in the database
-def update_db_cell(db_name, table_name, col_to_change, col_name, col_name_value, new_value):
+def update_db_cell(
+    db_name, table_name, col_to_change, col_name, col_name_value, new_value
+):
     conn = sqlite3.connect(db_name)
     cursor = conn.cursor()
 
@@ -12,27 +15,44 @@ def update_db_cell(db_name, table_name, col_to_change, col_name, col_name_value,
 
     conn.commit()
     conn.close()
-    print(f"Updated {col_to_change} to {new_value} for {col_name} = {col_name_value} in table {table_name}")
+    print(
+        f"Updated {col_to_change} to {new_value} for {col_name} = {col_name_value} in table {table_name}"
+    )
+
 
 # Main function to handle command-line arguments
 def main():
-    parser = argparse.ArgumentParser(description="Update a specific cell in the database.")
+    parser = argparse.ArgumentParser(
+        description="Update a specific cell in the database."
+    )
 
     # Required arguments
-    parser.add_argument('--db', required=True, help="Database name")
-    parser.add_argument('--table', required=True, help="Table name")
-    parser.add_argument('--colchange', required=True, help="Column to change")
-    parser.add_argument('--colname', required=True, help="Column name to identify the row")
-    parser.add_argument('--colnamerow', required=True, help="Value of the identifying column")
-    parser.add_argument('--newval', required=True, help="New value to set")
+    parser.add_argument("--db", required=True, help="Database name")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument("--colchange", required=True, help="Column to change")
+    parser.add_argument(
+        "--colname", required=True, help="Column name to identify the row"
+    )
+    parser.add_argument(
+        "--colnamerow", required=True, help="Value of the identifying column"
+    )
+    parser.add_argument("--newval", required=True, help="New value to set")
 
     args = parser.parse_args()
 
     try:
         # Call the update function with the provided arguments
-        update_db_cell(args.db, args.table, args.colchange, args.colname, args.colnamerow, args.newval)
+        update_db_cell(
+            args.db,
+            args.table,
+            args.colchange,
+            args.colname,
+            args.colnamerow,
+            args.newval,
+        )
     except Exception as e:
         print(f"Error: {e}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/ux.py
+++ b/ux.py
@@ -5,15 +5,17 @@ import subprocess
 
 app = Flask(__name__)
 
-DATABASE = 'styring.db'
+DATABASE = "styring.db"
+
 
 def get_db_connection():
     conn = sqlite3.connect(DATABASE)
     conn.row_factory = sqlite3.Row  # Enable dict-like access to rows
     return conn
 
+
 # Custom Jinja2 filter to format datetime strings
-@app.template_filter('datetimeformat')
+@app.template_filter("datetimeformat")
 def datetimeformat(value):
     if value:
         try:
@@ -28,60 +30,76 @@ def datetimeformat(value):
     else:
         return "N/A"
 
-@app.route('/')
+
+@app.route("/")
 def index():
     conn = get_db_connection()
-    devices = conn.execute('SELECT * FROM heimtaugaskapar').fetchall()
+    devices = conn.execute("SELECT * FROM heimtaugaskapar").fetchall()
     conn.close()
 
     # Organize devices by hverfi
     hverfi_dict = {}
     for device in devices:
-        hverfi = device['hverfi']
+        hverfi = device["hverfi"]
         if hverfi not in hverfi_dict:
             hverfi_dict[hverfi] = []
         hverfi_dict[hverfi].append(device)
 
-    return render_template('index.html', hverfi_dict=hverfi_dict)
+    return render_template("index.html", hverfi_dict=hverfi_dict)
 
-@app.route('/update_astroman', methods=['POST'])
+
+@app.route("/update_astroman", methods=["POST"])
 def update_astroman():
-    device_id = request.form['device_id']
-    new_mode = request.form['astroman']
+    device_id = request.form["device_id"]
+    new_mode = request.form["astroman"]
     conn = get_db_connection()
-    conn.execute('UPDATE heimtaugaskapar SET astroman = ? WHERE id = ?', (new_mode, device_id))
+    conn.execute(
+        "UPDATE heimtaugaskapar SET astroman = ? WHERE id = ?", (new_mode, device_id)
+    )
     conn.commit()
     conn.close()
-    return redirect(url_for('index'))
+    return redirect(url_for("index"))
 
-@app.route('/update_uxstate', methods=['POST'])
+
+@app.route("/update_uxstate", methods=["POST"])
 def update_uxstate():
-    device_id = request.form['device_id']
-    new_state = request.form['uxstate']
+    device_id = request.form["device_id"]
+    new_state = request.form["uxstate"]
     conn = get_db_connection()
 
     # Get current outputstate
-    device = conn.execute('SELECT outputstate FROM heimtaugaskapar WHERE id = ?', (device_id,)).fetchone()
+    device = conn.execute(
+        "SELECT outputstate FROM heimtaugaskapar WHERE id = ?", (device_id,)
+    ).fetchone()
     if device is not None:
-        current_outputstate = device['outputstate']
+        current_outputstate = device["outputstate"]
         if new_state != current_outputstate:
             # Call apiTurn.py with appropriate arguments
-            result = subprocess.run(['python3', 'apiTurn.py', '--id', device_id, '--turn', new_state], capture_output=True, text=True)
+            result = subprocess.run(
+                ["python3", "apiTurn.py", "--id", device_id, "--turn", new_state],
+                capture_output=True,
+                text=True,
+            )
             if result.returncode != 0:
                 print(f"Error executing apiTurn.py: {result.stderr}")
                 # Optionally, handle the error (e.g., flash message to the user)
             else:
                 print(f"apiTurn.py output: {result.stdout}")
         else:
-            print(f"No action needed for device {device_id}. Desired state '{new_state}' matches current outputstate.")
+            print(
+                f"No action needed for device {device_id}. Desired state '{new_state}' matches current outputstate."
+            )
     else:
         print(f"Device {device_id} not found in database.")
 
     # Update uxstate in database
-    conn.execute('UPDATE heimtaugaskapar SET uxstate = ? WHERE id = ?', (new_state, device_id))
+    conn.execute(
+        "UPDATE heimtaugaskapar SET uxstate = ? WHERE id = ?", (new_state, device_id)
+    )
     conn.commit()
     conn.close()
-    return redirect(url_for('index'))
+    return redirect(url_for("index"))
 
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5051)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5051)

--- a/ux.py
+++ b/ux.py
@@ -1,7 +1,8 @@
-from flask import Flask, render_template, request, redirect, url_for
 import sqlite3
-from datetime import datetime
 import subprocess
+from datetime import datetime
+
+from flask import Flask, redirect, render_template, request, url_for
 
 app = Flask(__name__)
 


### PR DESCRIPTION
**Warning**: This change set is untested, though since the changes were made with a tool, it seems unlikely anything would have been broken.

I was unable to find any instructions on how I might set up my own development environment to test my changes. Adding unit or integration tests may be beneficial to have in the future.

---

This set of changes applies the fixes suggested by the [Ruff](https://docs.astral.sh/ruff/) tool.

The primary changes include:

- Remove unused imports (fba847d255e62b84eeae9b4cb36c52b05bc55e1d)
- Break up long lines into multiple lines
- Change single quotes (`'`) to double quotes (`"`). (Docs: <https://docs.astral.sh/ruff/settings/#format_quote-style>)
    > In compliance with [PEP 8](https://peps.python.org/pep-0008/) and [PEP 257](https://peps.python.org/pep-0257/), Ruff prefers double quotes for triple quoted strings and docstrings [...]

[isort](https://pycqa.github.io/isort/) was used to sort the imports according to the [PEP 8](https://peps.python.org/pep-0008/) standard as follows:

> Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants.
>
> Imports should be grouped in the following order:
>
>   1. Standard library imports.
>   2. Related third party imports.
>   3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.