### PR TITLE
Move URL parameters into Python dictionary

### DIFF
--- a/apiState.py
+++ b/apiState.py
@@ -72,12 +72,17 @@ def check_pin_state(device_info, var):
     pin = device_info['input_pin'] if var == 'inputstate' else device_info['output_pin']
 
     # Construct the URL with plain-text credentials in the query string
-    url = f"http://{ip}/cgi-bin/io_value?username={USERNAME}&password={PASSWORD}&pin={pin}"
+    url = f"http://{ip}/cgi-bin/io_value"
+    payload = {
+        "username": USERNAME,
+        "password": PASSWORD,
+        "pin": pin,
+    }
 
     # Send the request
     for attempt in range(RETRY_LIMIT):
         try:
-            response = requests.get(url, timeout=TIMEOUT)
+            response = requests.get(url, params=payload, timeout=TIMEOUT)
 
             if response.status_code == 200:
                 pin_state = response.text.strip()  # Get the pin state from the API response (0 or 1)

--- a/apiTurn.py
+++ b/apiTurn.py
@@ -54,15 +54,23 @@ def turn_output(device_info, state):
     pin = device_info['output_pin']
 
     # Construct the URL with plain-text credentials in the query string
-    url = f"http://{ip}/cgi-bin/io_state?username={USERNAME}&password={PASSWORD}&pin={pin}&state={state.lower()}"
+    url = f"http://{ip}/cgi-bin/io_state"
+    payload = {
+        "username": USERNAME,
+        "password": PASSWORD,
+        "pin": pin,
+        "state": state.lower(),
+    }
 
     # Print the URL without exposing the password
-    print(f"API URL: http://{ip}/cgi-bin/io_state?username={USERNAME}&pin={pin}&state={state.lower()} [password hidden]")
-    
+    print(
+        f"API URL: {url}?username={USERNAME}&pin={pin}&state={state.lower()} [password hidden]"
+    )
+
     # Send the request
     for attempt in range(RETRY_LIMIT):
         try:
-            response = requests.get(url, timeout=TIMEOUT)
+            response = requests.get(url, params=payload, timeout=TIMEOUT)
 
             if response.status_code == 200:
                 print(f"Successfully turned {state.upper()} {pin} for device with IP {ip}")
@@ -82,11 +90,16 @@ def check_and_update_pin_state(device_info, var):
     ip = device_info['ip']
     pin = device_info['input_pin'] if var == 'inputstate' else device_info['output_pin']
 
-    url = f"http://{ip}/cgi-bin/io_value?username={USERNAME}&password={PASSWORD}&pin={pin}"
-    
+    url = f"http://{ip}/cgi-bin/io_value"
+    payload = {
+        "username": USERNAME,
+        "password": PASSWORD,
+        "pin": pin,
+    }
+
     # Send the request
     try:
-        response = requests.get(url, timeout=TIMEOUT)
+        response = requests.get(url, params=payload, timeout=TIMEOUT)
         if response.status_code == 200:
             pin_state = response.text.strip()  # Get the pin state (0 or 1)
             new_value = 'ON' if pin_state == '1' else 'OFF'


### PR DESCRIPTION
Warning: This change set is untested.

I was unable to find any instructions on how I might set up my own development environment to test my changes. Adding unit or integration tests may be beneficial to have in the future.

---

Having the URL parameters defined in a dictionary is not only better for readability and maintainability, it also provides the benefit of correctly encoding strings to be safe for use within URLS.

See the Python requests documentation:
<https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls>